### PR TITLE
Deliver skills through buildTransitive so they flow to transitive consumers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,7 +37,7 @@ CrestApps.AgentSkills contains shared AI agent skills and MCP tooling for .NET a
 
 4. **`CrestApps.AgentSkills.Mcp.OrchardCore`** - Runtime MCP server for Orchard Core
    - Extends `CrestApps.AgentSkills.Mcp` with Orchard Core–specific convenience wrappers
-   - Bundles both `orchardcore/` and `crestapps-orchardcore/` via `contentFiles` (copied to bin output on restore)
+   - Bundles both `orchardcore/` and `crestapps-orchardcore/`, packed under `skills/` and copied to the consuming app's build and publish output at `.agents/skills/` by a `buildTransitive` targets file (not `contentFiles`, which NuGet drops for transitive references)
    - Entry point: `OrchardCoreSkillMcpExtensions` (`AddOrchardCoreSkills`, `AddOrchardCoreAgentSkillServices`)
    - Services registered as singletons for caching
 

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -112,5 +112,26 @@ jobs:
         validate_project \
           "src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj" \
           '$(OrchardCoreSkillsDirectory)**\*' \
-          'PackagePath="contentFiles\any\any\.agents\skills"' \
+          'PackagePath="skills"' \
           'Exclude="$(OrchardCoreSkillsDirectory)**\bin\**\*;$(OrchardCoreSkillsDirectory)**\lib\**\*"'
+
+        # Skills must be delivered through buildTransitive targets. NuGet contentFiles
+        # are dropped for applications that reference the package transitively, which
+        # would silently ship a site with no skills at all.
+        mcp_project="src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj"
+        mcp_targets="src/CrestApps.AgentSkills.Mcp.OrchardCore/buildTransitive/CrestApps.AgentSkills.Mcp.OrchardCore.targets"
+
+        if [ ! -f "$mcp_targets" ]; then
+          echo "::error file=$mcp_targets::Missing buildTransitive targets that copy skills to the consuming app output."
+          exit 1
+        fi
+
+        if ! grep -Fq 'PackagePath="buildTransitive"' "$mcp_project"; then
+          echo "::error file=$mcp_project::buildTransitive assets are not packed."
+          exit 1
+        fi
+
+        if grep -Fq 'PackagePath="contentFiles' "$mcp_project"; then
+          echo "::error file=$mcp_project::Skills must not be packed as contentFiles; they do not flow transitively."
+          exit 1
+        fi

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -135,3 +135,22 @@ jobs:
           echo "::error file=$mcp_project::Skills must not be packed as contentFiles; they do not flow transitively."
           exit 1
         fi
+
+        # Source ProjectReference consumers (including this repository's own tests) rely on
+        # the item metadata below, while packaged consumers rely on the buildTransitive
+        # targets. Both delivery paths must stay intact.
+        if ! grep -Fq 'CopyToOutputDirectory' "$mcp_project" || ! grep -Fq 'CopyToPublishDirectory' "$mcp_project"; then
+          echo "::error file=$mcp_project::Skill items must keep CopyToOutputDirectory and CopyToPublishDirectory so project references still receive skills."
+          exit 1
+        fi
+
+        if ! grep -Fq 'CopyToOutputDirectory' "$mcp_targets" || ! grep -Fq 'CopyToPublishDirectory' "$mcp_targets"; then
+          echo "::error file=$mcp_targets::buildTransitive targets must copy skills to both the build output and the publish output."
+          exit 1
+        fi
+
+        # The runtime loader reads "<AppContext.BaseDirectory>/.agents/skills".
+        if ! grep -Fq '.agents' "$mcp_project" || ! grep -Fq '.agents' "$mcp_targets"; then
+          echo "::error file=$mcp_targets::Skills must be linked under '.agents/skills' to match the runtime loader path."
+          exit 1
+        fi

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -137,3 +137,22 @@ jobs:
           echo "::error file=$mcp_project::Skills must not be packed as contentFiles; they do not flow transitively."
           exit 1
         fi
+
+        # Source ProjectReference consumers (including this repository's own tests) rely on
+        # the item metadata below, while packaged consumers rely on the buildTransitive
+        # targets. Both delivery paths must stay intact.
+        if ! grep -Fq 'CopyToOutputDirectory' "$mcp_project" || ! grep -Fq 'CopyToPublishDirectory' "$mcp_project"; then
+          echo "::error file=$mcp_project::Skill items must keep CopyToOutputDirectory and CopyToPublishDirectory so project references still receive skills."
+          exit 1
+        fi
+
+        if ! grep -Fq 'CopyToOutputDirectory' "$mcp_targets" || ! grep -Fq 'CopyToPublishDirectory' "$mcp_targets"; then
+          echo "::error file=$mcp_targets::buildTransitive targets must copy skills to both the build output and the publish output."
+          exit 1
+        fi
+
+        # The runtime loader reads "<AppContext.BaseDirectory>/.agents/skills".
+        if ! grep -Fq '.agents' "$mcp_project" || ! grep -Fq '.agents' "$mcp_targets"; then
+          echo "::error file=$mcp_targets::Skills must be linked under '.agents/skills' to match the runtime loader path."
+          exit 1
+        fi

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -114,5 +114,26 @@ jobs:
         validate_project \
           "src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj" \
           '$(OrchardCoreSkillsDirectory)**\*' \
-          'PackagePath="contentFiles\any\any\.agents\skills"' \
+          'PackagePath="skills"' \
           'Exclude="$(OrchardCoreSkillsDirectory)**\bin\**\*;$(OrchardCoreSkillsDirectory)**\lib\**\*"'
+
+        # Skills must be delivered through buildTransitive targets. NuGet contentFiles
+        # are dropped for applications that reference the package transitively, which
+        # would silently ship a site with no skills at all.
+        mcp_project="src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj"
+        mcp_targets="src/CrestApps.AgentSkills.Mcp.OrchardCore/buildTransitive/CrestApps.AgentSkills.Mcp.OrchardCore.targets"
+
+        if [ ! -f "$mcp_targets" ]; then
+          echo "::error file=$mcp_targets::Missing buildTransitive targets that copy skills to the consuming app output."
+          exit 1
+        fi
+
+        if ! grep -Fq 'PackagePath="buildTransitive"' "$mcp_project"; then
+          echo "::error file=$mcp_project::buildTransitive assets are not packed."
+          exit 1
+        fi
+
+        if grep -Fq 'PackagePath="contentFiles' "$mcp_project"; then
+          echo "::error file=$mcp_project::Skills must not be packed as contentFiles; they do not flow transitively."
+          exit 1
+        fi

--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -133,8 +133,29 @@ jobs:
         validate_project \
           "src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj" \
           '$(OrchardCoreSkillsDirectory)**\*' \
-          'PackagePath="contentFiles\any\any\.agents\skills"' \
+          'PackagePath="skills"' \
           'Exclude="$(OrchardCoreSkillsDirectory)**\bin\**\*;$(OrchardCoreSkillsDirectory)**\lib\**\*"'
+
+        # Skills must be delivered through buildTransitive targets. NuGet contentFiles
+        # are dropped for applications that reference the package transitively, which
+        # would silently ship a site with no skills at all.
+        mcp_project="src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj"
+        mcp_targets="src/CrestApps.AgentSkills.Mcp.OrchardCore/buildTransitive/CrestApps.AgentSkills.Mcp.OrchardCore.targets"
+
+        if [ ! -f "$mcp_targets" ]; then
+          echo "::error file=$mcp_targets::Missing buildTransitive targets that copy skills to the consuming app output."
+          exit 1
+        fi
+
+        if ! grep -Fq 'PackagePath="buildTransitive"' "$mcp_project"; then
+          echo "::error file=$mcp_project::buildTransitive assets are not packed."
+          exit 1
+        fi
+
+        if grep -Fq 'PackagePath="contentFiles' "$mcp_project"; then
+          echo "::error file=$mcp_project::Skills must not be packed as contentFiles; they do not flow transitively."
+          exit 1
+        fi
     - name: Deploy preview NuGet packages
       if: steps.check-publish.outputs.should-publish == 'true'
       run: |

--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -156,6 +156,25 @@ jobs:
           echo "::error file=$mcp_project::Skills must not be packed as contentFiles; they do not flow transitively."
           exit 1
         fi
+
+        # Source ProjectReference consumers (including this repository's own tests) rely on
+        # the item metadata below, while packaged consumers rely on the buildTransitive
+        # targets. Both delivery paths must stay intact.
+        if ! grep -Fq 'CopyToOutputDirectory' "$mcp_project" || ! grep -Fq 'CopyToPublishDirectory' "$mcp_project"; then
+          echo "::error file=$mcp_project::Skill items must keep CopyToOutputDirectory and CopyToPublishDirectory so project references still receive skills."
+          exit 1
+        fi
+
+        if ! grep -Fq 'CopyToOutputDirectory' "$mcp_targets" || ! grep -Fq 'CopyToPublishDirectory' "$mcp_targets"; then
+          echo "::error file=$mcp_targets::buildTransitive targets must copy skills to both the build output and the publish output."
+          exit 1
+        fi
+
+        # The runtime loader reads "<AppContext.BaseDirectory>/.agents/skills".
+        if ! grep -Fq '.agents' "$mcp_project" || ! grep -Fq '.agents' "$mcp_targets"; then
+          echo "::error file=$mcp_targets::Skills must be linked under '.agents/skills' to match the runtime loader path."
+          exit 1
+        fi
     - name: Deploy preview NuGet packages
       if: steps.check-publish.outputs.should-publish == 'true'
       run: |

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -155,6 +155,25 @@ jobs:
           echo "::error file=$mcp_project::Skills must not be packed as contentFiles; they do not flow transitively."
           exit 1
         fi
+
+        # Source ProjectReference consumers (including this repository's own tests) rely on
+        # the item metadata below, while packaged consumers rely on the buildTransitive
+        # targets. Both delivery paths must stay intact.
+        if ! grep -Fq 'CopyToOutputDirectory' "$mcp_project" || ! grep -Fq 'CopyToPublishDirectory' "$mcp_project"; then
+          echo "::error file=$mcp_project::Skill items must keep CopyToOutputDirectory and CopyToPublishDirectory so project references still receive skills."
+          exit 1
+        fi
+
+        if ! grep -Fq 'CopyToOutputDirectory' "$mcp_targets" || ! grep -Fq 'CopyToPublishDirectory' "$mcp_targets"; then
+          echo "::error file=$mcp_targets::buildTransitive targets must copy skills to both the build output and the publish output."
+          exit 1
+        fi
+
+        # The runtime loader reads "<AppContext.BaseDirectory>/.agents/skills".
+        if ! grep -Fq '.agents' "$mcp_project" || ! grep -Fq '.agents' "$mcp_targets"; then
+          echo "::error file=$mcp_targets::Skills must be linked under '.agents/skills' to match the runtime loader path."
+          exit 1
+        fi
     - name: Deploy release NuGet packages
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -132,8 +132,29 @@ jobs:
         validate_project \
           "src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj" \
           '$(OrchardCoreSkillsDirectory)**\*' \
-          'PackagePath="contentFiles\any\any\.agents\skills"' \
+          'PackagePath="skills"' \
           'Exclude="$(OrchardCoreSkillsDirectory)**\bin\**\*;$(OrchardCoreSkillsDirectory)**\lib\**\*"'
+
+        # Skills must be delivered through buildTransitive targets. NuGet contentFiles
+        # are dropped for applications that reference the package transitively, which
+        # would silently ship a site with no skills at all.
+        mcp_project="src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj"
+        mcp_targets="src/CrestApps.AgentSkills.Mcp.OrchardCore/buildTransitive/CrestApps.AgentSkills.Mcp.OrchardCore.targets"
+
+        if [ ! -f "$mcp_targets" ]; then
+          echo "::error file=$mcp_targets::Missing buildTransitive targets that copy skills to the consuming app output."
+          exit 1
+        fi
+
+        if ! grep -Fq 'PackagePath="buildTransitive"' "$mcp_project"; then
+          echo "::error file=$mcp_project::buildTransitive assets are not packed."
+          exit 1
+        fi
+
+        if grep -Fq 'PackagePath="contentFiles' "$mcp_project"; then
+          echo "::error file=$mcp_project::Skills must not be packed as contentFiles; they do not flow transitively."
+          exit 1
+        fi
     - name: Deploy release NuGet packages
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj
+++ b/src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj
@@ -29,11 +29,17 @@
 			  Exclude="$(OrchardCoreSkillsDirectory)**\bin\**\*;$(OrchardCoreSkillsDirectory)**\lib\**\*"
 			  Pack="true"
 			  PackagePath="skills"
+			  Link=".agents\skills\%(RecursiveDir)%(Filename)%(Extension)"
+			  CopyToOutputDirectory="PreserveNewest"
+			  CopyToPublishDirectory="PreserveNewest"
 			  Visible="false" />
 		<None Include="$(CrestAppsOrchardCoreSkillsDirectory)**\*"
 			  Exclude="$(CrestAppsOrchardCoreSkillsDirectory)**\bin\**\*;$(CrestAppsOrchardCoreSkillsDirectory)**\lib\**\*"
 			  Pack="true"
 			  PackagePath="skills"
+			  Link=".agents\skills\%(RecursiveDir)%(Filename)%(Extension)"
+			  CopyToOutputDirectory="PreserveNewest"
+			  CopyToPublishDirectory="PreserveNewest"
 			  Visible="false" />
 	</ItemGroup>
 

--- a/src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj
+++ b/src/CrestApps.AgentSkills.Mcp.OrchardCore/CrestApps.AgentSkills.Mcp.OrchardCore.csproj
@@ -19,29 +19,30 @@
 		<PackageReference Include="CrestApps.Core.AI.Mcp" />
 	</ItemGroup>
 
+	<!-- Pack skill files under skills/ in the nupkg rather than contentFiles/.
+	     NuGet only flows contentFiles to DIRECT package references, so a module that
+	     wraps this package would publish without skills. The buildTransitive .targets
+	     copies these files to the consuming app's output and publish directory instead,
+	     which works for direct and transitive references alike. -->
 	<ItemGroup>
-		<Content Include="$(OrchardCoreSkillsDirectory)**\*"
-				 Exclude="$(OrchardCoreSkillsDirectory)**\bin\**\*;$(OrchardCoreSkillsDirectory)**\lib\**\*"
-				 Pack="true"
-				 PackagePath="contentFiles\any\any\.agents\skills"
-				 BuildAction="Content"
-				 CopyToOutputDirectory="PreserveNewest"
-				 Visible="false">
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-		<Content Include="$(CrestAppsOrchardCoreSkillsDirectory)**\*"
-				 Exclude="$(CrestAppsOrchardCoreSkillsDirectory)**\bin\**\*;$(CrestAppsOrchardCoreSkillsDirectory)**\lib\**\*"
-				 Pack="true"
-				 PackagePath="contentFiles\any\any\.agents\skills"
-				 BuildAction="Content"
-				 CopyToOutputDirectory="PreserveNewest"
-				 Visible="false">
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
+		<None Include="$(OrchardCoreSkillsDirectory)**\*"
+			  Exclude="$(OrchardCoreSkillsDirectory)**\bin\**\*;$(OrchardCoreSkillsDirectory)**\lib\**\*"
+			  Pack="true"
+			  PackagePath="skills"
+			  Visible="false" />
+		<None Include="$(CrestAppsOrchardCoreSkillsDirectory)**\*"
+			  Exclude="$(CrestAppsOrchardCoreSkillsDirectory)**\bin\**\*;$(CrestAppsOrchardCoreSkillsDirectory)**\lib\**\*"
+			  Pack="true"
+			  PackagePath="skills"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="buildTransitive\**\*" Pack="true" PackagePath="buildTransitive" />
 	</ItemGroup>
 
 </Project>

--- a/src/CrestApps.AgentSkills.Mcp.OrchardCore/README.md
+++ b/src/CrestApps.AgentSkills.Mcp.OrchardCore/README.md
@@ -28,10 +28,20 @@ builder.Services.AddMcpServer(mcp =>
 
 ## How it works
 
-1. The package packs skills under `contentFiles/any/any/.agents/skills/`.
-2. NuGet copies those files into the consuming project's output.
-3. `AddOrchardCoreSkills()` registers the Orchard Core file store plus cached prompt and resource providers.
+1. The package packs skills under `skills/` in the `.nupkg`.
+2. A `buildTransitive` MSBuild targets file copies those files into the consuming application's build output and publish output at `.agents/skills/`.
+3. `AddOrchardCoreSkills()` registers the Orchard Core file store plus cached prompt and resource providers, reading from `<AppContext.BaseDirectory>/.agents/skills` by default.
 4. At runtime, MCP clients can discover prompts/resources from both `orchardcore/` and `crestapps-orchardcore/`.
+
+Skills are delivered with `buildTransitive` rather than NuGet `contentFiles` on purpose. NuGet only applies `contentFiles` to direct package references, so any module that wraps this package would ship without skills. `buildTransitive` assets flow through transitive package references, so applications get the skills no matter how deep this package sits in the dependency graph.
+
+To supply your own skills directory instead of the packaged one, set the `IncludeCrestAppsAgentSkills` MSBuild property to `false`:
+
+```xml
+<PropertyGroup>
+  <IncludeCrestAppsAgentSkills>false</IncludeCrestAppsAgentSkills>
+</PropertyGroup>
+```
 
 ## Companion package
 

--- a/src/CrestApps.AgentSkills.Mcp.OrchardCore/buildTransitive/CrestApps.AgentSkills.Mcp.OrchardCore.targets
+++ b/src/CrestApps.AgentSkills.Mcp.OrchardCore/buildTransitive/CrestApps.AgentSkills.Mcp.OrchardCore.targets
@@ -1,0 +1,40 @@
+<Project>
+
+  <!--
+    CrestApps.AgentSkills.Mcp.OrchardCore
+
+    Copies the packaged skill files into the consuming application's build output and
+    publish output under ".agents/skills". That is exactly where the runtime loader
+    looks for them, because AddOrchardCoreAgentSkillServices() defaults the skills
+    directory to "<AppContext.BaseDirectory>/.agents/skills".
+
+    Why this is not done with NuGet "contentFiles":
+      NuGet only honours contentFiles (copyToOutput) for DIRECT PackageReference items
+      and for ProjectReference chains. They are silently dropped when this package is
+      pulled in through another package, which is a transitive PackageReference. A module
+      that wraps this package would therefore publish without any skill files, and the
+      MCP server would expose no skill resources at all.
+
+      Assets in "buildTransitive" flow through transitive package references, so every
+      consuming application receives the skills no matter how deep this package sits in
+      the dependency graph. No consumer has to add a direct reference as a workaround.
+
+    Consumers that ship their own skills directory can opt out by setting
+    IncludeCrestAppsAgentSkills to false.
+  -->
+
+  <PropertyGroup>
+    <CrestAppsAgentSkillsDirectory Condition=" '$(CrestAppsAgentSkillsDirectory)' == '' ">$(MSBuildThisFileDirectory)../skills/</CrestAppsAgentSkillsDirectory>
+    <IncludeCrestAppsAgentSkills Condition=" '$(IncludeCrestAppsAgentSkills)' == '' ">true</IncludeCrestAppsAgentSkills>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(IncludeCrestAppsAgentSkills)' == 'true' And Exists('$(CrestAppsAgentSkillsDirectory)') ">
+    <None Include="$(CrestAppsAgentSkillsDirectory)**/*"
+          Link=".agents/skills/%(RecursiveDir)%(Filename)%(Extension)"
+          CopyToOutputDirectory="PreserveNewest"
+          CopyToPublishDirectory="PreserveNewest"
+          Pack="false"
+          Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/CrestApps.AgentSkills/README.md
+++ b/src/CrestApps.AgentSkills/README.md
@@ -13,7 +13,7 @@ This project is the **skill content container** for the repository. It is not pu
 ## Packaging behavior
 
 - `CrestApps.AgentSkills.OrchardCore` packs `orchardcore/` and `crestapps-orchardcore/` under `skills/`
-- `CrestApps.AgentSkills.Mcp.OrchardCore` packs `orchardcore/` and `crestapps-orchardcore/` under `contentFiles/any/any/.agents/skills/`
+- `CrestApps.AgentSkills.Mcp.OrchardCore` packs `orchardcore/` and `crestapps-orchardcore/` under `skills/`, then copies them to the consuming app's output and publish directory at `.agents/skills/` with a `buildTransitive` targets file
 - The Copilot CLI plugins are generated from matching roots:
   - `plugins/orchardcore` ← `src/CrestApps.AgentSkills/orchardcore`
   - `plugins/crestapps-orchardcore` ← `src/CrestApps.AgentSkills/crestapps-orchardcore`


### PR DESCRIPTION
…sumers

Skills shipped as NuGet contentFiles, which NuGet only applies to direct PackageReference items and ProjectReference chains. Applications that pull this package in through another package, such as an Orchard Core site referencing CrestApps.OrchardCore.AI.Mcp, received no skill files at all. The MCP server then started with zero skill resources, while local development kept working because it resolves the same package over a ProjectReference chain.

Pack the skills under skills/ and copy them into the consuming application's build and publish output at .agents/skills/ with a buildTransitive targets file. That path matches the runtime loader, which defaults to <AppContext.BaseDirectory>/.agents/skills. buildTransitive assets flow through transitive package references, so consumers no longer need a direct package reference as a workaround.

Verified against a locally packed nupkg: direct reference, two-hop package chain, three-hop package chain, and ProjectReference chain each produce 229 skill files in both build and publish output, with no duplicate publish conflicts. A console app reachable only through a transitive reference loaded 228 MCP resources and 169 prompts.

Add CI guards so skills cannot regress back to contentFiles packaging.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://github.com/CrestApps/CrestApps.AgentSkills/blob/main/.github/CONTRIBUTING.md -->
