### PR TITLE
Fix MCP prompt/resource exposure for agent skills

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <VersionSuffix>preview</VersionSuffix>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <InformationalVersion></InformationalVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="OrchardCore.FileStorage.FileSystem" Version="2.2.1" />
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup>
     <!-- Testing -->

--- a/src/CrestApps.AgentSkills.Mcp.OrchardCore/Extensions/OrchardCoreSkillMcpExtensions.cs
+++ b/src/CrestApps.AgentSkills.Mcp.OrchardCore/Extensions/OrchardCoreSkillMcpExtensions.cs
@@ -2,6 +2,7 @@ using CrestApps.AgentSkills.Mcp;
 using CrestApps.AgentSkills.Mcp.Extensions;
 using CrestApps.OrchardCore.AgentSkills.Mcp.Adapters;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using SdkPromptProvider = CrestApps.Core.AI.Mcp.Services.IMcpPromptProvider;
 using SdkResourceProvider = CrestApps.Core.AI.Mcp.Services.IMcpResourceProvider;
 using SkillPromptProvider = CrestApps.AgentSkills.Mcp.Abstractions.IMcpPromptProvider;
@@ -54,13 +55,19 @@ public static class OrchardCoreSkillMcpExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
 
-        var orchardOptions = new OrchardCoreSkillOptions();
-        configure(orchardOptions);
+        // Register the Orchard Core options through the standard options pipeline so
+        // IOptions<OrchardCoreSkillOptions> is resolvable and consumers can post-configure.
+        services.Configure(configure);
 
-        services.AddAgentSkillServices(options =>
-        {
-            options.Path = orchardOptions.Path;
-        });
+        services.AddAgentSkillServices();
+
+        // Bridge the Orchard Core options onto the underlying AgentSkillOptions via the
+        // options pipeline, so later post-configuration of OrchardCoreSkillOptions is honored.
+        services.AddOptions<AgentSkillOptions>()
+            .Configure<IOptions<OrchardCoreSkillOptions>>((options, orchardOptions) =>
+            {
+                options.Path = orchardOptions.Value.Path;
+            });
 
         // Register adapters that bridge AgentSkills' provider interfaces to the
         // CrestApps.Core SDK interfaces so the SDK's DefaultMcpServerPromptService
@@ -98,6 +105,12 @@ public static class OrchardCoreSkillMcpExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(configure);
 
+        // Register the Orchard Core options through the standard options pipeline so
+        // IOptions<OrchardCoreSkillOptions> is resolvable at runtime.
+        builder.Services.Configure(configure);
+
+        // Prompts/resources are loaded eagerly at configuration time (before any service
+        // provider exists), so the path must be resolved synchronously here.
         var orchardOptions = new OrchardCoreSkillOptions();
         configure(orchardOptions);
 

--- a/src/CrestApps.AgentSkills.Mcp/AgentSkillOptions.cs
+++ b/src/CrestApps.AgentSkills.Mcp/AgentSkillOptions.cs
@@ -10,4 +10,12 @@ public sealed class AgentSkillOptions
     /// When <c>null</c>, the default path (<c>&lt;AppContext.BaseDirectory&gt;/.agents/skills</c>) is used.
     /// </summary>
     public string? Path { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default MCP channel used for skills that do not declare an
+    /// <c>mcp</c> front-matter key (or declare an unrecognized value).
+    /// Defaults to <see cref="McpChannel.Both"/>, which preserves the original behavior of
+    /// exposing every skill as both a prompt and a resource.
+    /// </summary>
+    public McpChannel DefaultMcpChannel { get; set; } = McpChannel.Both;
 }

--- a/src/CrestApps.AgentSkills.Mcp/CrestApps.AgentSkills.Mcp.csproj
+++ b/src/CrestApps.AgentSkills.Mcp/CrestApps.AgentSkills.Mcp.csproj
@@ -12,6 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Options" />
 		<PackageReference Include="ModelContextProtocol" />
 		<PackageReference Include="YamlDotNet" />
 	</ItemGroup>

--- a/src/CrestApps.AgentSkills.Mcp/Extensions/AgentSkillMcpExtensions.cs
+++ b/src/CrestApps.AgentSkills.Mcp/Extensions/AgentSkillMcpExtensions.cs
@@ -3,6 +3,7 @@ using CrestApps.AgentSkills.Mcp.Providers;
 using CrestApps.AgentSkills.Mcp.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace CrestApps.AgentSkills.Mcp.Extensions;
 
@@ -43,13 +44,19 @@ public static class AgentSkillMcpExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
 
-        var options = new AgentSkillOptions();
-        configure(options);
+        // Register the options through the standard options pipeline so that
+        // IOptions<AgentSkillOptions> is resolvable and consumers can post-configure.
+        services.Configure(configure);
 
-        var skillsPath = options.Path
-            ?? Path.Combine(AppContext.BaseDirectory, DefaultSkillsRelativePath);
+        // Resolve the skills path lazily from the configured options.
+        services.AddSingleton<IAgentSkillFilesStore>(sp =>
+        {
+            var options = sp.GetRequiredService<IOptions<AgentSkillOptions>>().Value;
+            var skillsPath = options.Path
+                ?? Path.Combine(AppContext.BaseDirectory, DefaultSkillsRelativePath);
 
-        services.AddSingleton<IAgentSkillFilesStore>(new DefaultAgentSkillFilesStore(skillsPath));
+            return new DefaultAgentSkillFilesStore(skillsPath);
+        });
         services.AddSingleton<IMcpPromptProvider, SkillPromptProvider>();
         services.AddSingleton<IMcpResourceProvider, SkillResourceProvider>();
 
@@ -100,8 +107,9 @@ public static class AgentSkillMcpExtensions
         // These are temporary instances for config-time loading only;
         // the DI-registered singletons (with proper loggers) are used at runtime.
         var fileStore = new DefaultAgentSkillFilesStore(skillsPath);
-        var promptProvider = new SkillPromptProvider(fileStore, NullLogger<SkillPromptProvider>.Instance);
-        var resourceProvider = new SkillResourceProvider(fileStore, NullLogger<SkillResourceProvider>.Instance);
+        var optionsAccessor = Options.Create(options);
+        var promptProvider = new SkillPromptProvider(fileStore, NullLogger<SkillPromptProvider>.Instance, optionsAccessor);
+        var resourceProvider = new SkillResourceProvider(fileStore, NullLogger<SkillResourceProvider>.Instance, optionsAccessor);
 
         var prompts = promptProvider.GetPromptsAsync().GetAwaiter().GetResult();
         if (prompts.Count > 0)

--- a/src/CrestApps.AgentSkills.Mcp/McpChannel.cs
+++ b/src/CrestApps.AgentSkills.Mcp/McpChannel.cs
@@ -1,0 +1,22 @@
+namespace CrestApps.AgentSkills.Mcp;
+
+/// <summary>
+/// Determines which MCP surface(s) a skill is exposed through.
+/// </summary>
+public enum McpChannel
+{
+    /// <summary>
+    /// Expose the skill as an MCP prompt only.
+    /// </summary>
+    Prompt,
+
+    /// <summary>
+    /// Expose the skill as an MCP resource only.
+    /// </summary>
+    Resource,
+
+    /// <summary>
+    /// Expose the skill as both an MCP prompt and an MCP resource.
+    /// </summary>
+    Both,
+}

--- a/src/CrestApps.AgentSkills.Mcp/Providers/SkillPromptProvider.cs
+++ b/src/CrestApps.AgentSkills.Mcp/Providers/SkillPromptProvider.cs
@@ -1,6 +1,7 @@
 using CrestApps.AgentSkills.Mcp.Abstractions;
 using CrestApps.AgentSkills.Mcp.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
 
 namespace CrestApps.AgentSkills.Mcp.Providers;
@@ -16,16 +17,20 @@ public sealed class SkillPromptProvider : IMcpPromptProvider
 {
     private readonly IAgentSkillFilesStore _fileStore;
     private readonly ILogger<SkillPromptProvider> _logger;
+    private readonly AgentSkillOptions _options;
     private IReadOnlyList<McpServerPrompt>? _prompts;
 
     public SkillPromptProvider(
         IAgentSkillFilesStore fileStore,
-        ILogger<SkillPromptProvider> logger)
+        ILogger<SkillPromptProvider> logger,
+        IOptions<AgentSkillOptions> options)
     {
         ArgumentNullException.ThrowIfNull(fileStore);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(options);
         _fileStore = fileStore;
         _logger = logger;
+        _options = options.Value;
     }
 
     /// <summary>
@@ -68,11 +73,25 @@ public sealed class SkillPromptProvider : IMcpPromptProvider
                 continue;
             }
 
-            if (!SkillFileParser.TryParse(skillFileName, content, out var name, out var description, out var body))
+            if (!SkillFileParser.TryParse(skillFileName, content, out var name, out var description, out var body, out var mcp))
             {
                 _logger.LogWarning(
                     "Skill file '{FileName}' for skill '{SkillName}' has invalid or missing required fields (name and description are required), skipping.",
                     skillFileName, skillDirName);
+                continue;
+            }
+
+            var channel = McpChannelResolver.Resolve(mcp, _options.DefaultMcpChannel, name, _logger);
+
+            if (channel is not (McpChannel.Prompt or McpChannel.Both))
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug(
+                        "Skill '{SkillName}' is configured for the '{Channel}' channel; not exposing it as a prompt.",
+                        name, channel);
+                }
+
                 continue;
             }
 

--- a/src/CrestApps.AgentSkills.Mcp/Providers/SkillResourceProvider.cs
+++ b/src/CrestApps.AgentSkills.Mcp/Providers/SkillResourceProvider.cs
@@ -1,6 +1,7 @@
 using CrestApps.AgentSkills.Mcp.Abstractions;
 using CrestApps.AgentSkills.Mcp.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
 
 namespace CrestApps.AgentSkills.Mcp.Providers;
@@ -16,16 +17,20 @@ public sealed class SkillResourceProvider : IMcpResourceProvider
 {
     private readonly IAgentSkillFilesStore _fileStore;
     private readonly ILogger<SkillResourceProvider> _logger;
+    private readonly AgentSkillOptions _options;
     private IReadOnlyList<McpServerResource>? _resources;
 
     public SkillResourceProvider(
         IAgentSkillFilesStore fileStore,
-        ILogger<SkillResourceProvider> logger)
+        ILogger<SkillResourceProvider> logger,
+        IOptions<AgentSkillOptions> options)
     {
         ArgumentNullException.ThrowIfNull(fileStore);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(options);
         _fileStore = fileStore;
         _logger = logger;
+        _options = options.Value;
     }
 
     /// <summary>
@@ -52,21 +57,35 @@ public sealed class SkillResourceProvider : IMcpResourceProvider
             var skillDirName = skillDir.Name;
 
             // Register the skill file as a resource.
-            var (skillFileName, skillContent, skillName, skillDescription) = await TryReadAndParseSkillFileAsync(skillDirName);
+            var parsed = await TryReadAndParseSkillFileAsync(skillDirName);
 
-            if (skillFileName is not null && skillContent is not null && skillName is not null && skillDescription is not null)
+            if (parsed is { } skill)
             {
-                var mimeType = GetMimeType(skillFileName);
-                var resource = McpServerResource.Create(
-                    () => skillContent,
-                    new McpServerResourceCreateOptions
-                    {
-                        Name = $"{skillName}/{skillFileName}",
-                        Description = skillDescription,
-                        UriTemplate = $"skills://{skillName}/{skillFileName}",
-                        MimeType = mimeType,
-                    });
-                resources.Add(resource);
+                var channel = McpChannelResolver.Resolve(skill.Mcp, _options.DefaultMcpChannel, skill.Name, _logger);
+
+                if (channel is McpChannel.Resource or McpChannel.Both)
+                {
+                    // Serve the front-matter-stripped body (matching the prompt), so internal
+                    // YAML keys (license, metadata, version, ...) are never leaked to clients.
+                    var body = skill.Body;
+                    var mimeType = GetMimeType(skill.FileName);
+                    var resource = McpServerResource.Create(
+                        () => body,
+                        new McpServerResourceCreateOptions
+                        {
+                            Name = $"{skill.Name}/{skill.FileName}",
+                            Description = skill.Description,
+                            UriTemplate = $"skills://{skill.Name}/{skill.FileName}",
+                            MimeType = mimeType,
+                        });
+                    resources.Add(resource);
+                }
+                else if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug(
+                        "Skill '{SkillName}' is configured for the '{Channel}' channel; not exposing SKILL as a resource.",
+                        skill.Name, channel);
+                }
             }
             else
             {
@@ -140,8 +159,7 @@ public sealed class SkillResourceProvider : IMcpResourceProvider
         return _resources;
     }
 
-    private async Task<(string? FileName, string? Content, string? Name, string? Description)> TryReadAndParseSkillFileAsync(
-        string skillDirName)
+    private async Task<ParsedSkill?> TryReadAndParseSkillFileAsync(string skillDirName)
     {
         foreach (var candidateFileName in SkillFileParser.SupportedSkillFileNames)
         {
@@ -173,7 +191,7 @@ public sealed class SkillResourceProvider : IMcpResourceProvider
                 continue;
             }
 
-            if (!SkillFileParser.TryParse(candidateFileName, content, out var name, out var description, out _))
+            if (!SkillFileParser.TryParse(candidateFileName, content, out var name, out var description, out var body, out var mcp))
             {
                 _logger.LogWarning(
                     "Skill file '{FileName}' for skill '{SkillName}' has invalid or missing required fields (name and description are required), skipping.",
@@ -181,11 +199,13 @@ public sealed class SkillResourceProvider : IMcpResourceProvider
                 continue;
             }
 
-            return (candidateFileName, content, name, description);
+            return new ParsedSkill(candidateFileName, name, description, body, mcp);
         }
 
-        return (null, null, null, null);
+        return null;
     }
+
+    private readonly record struct ParsedSkill(string FileName, string Name, string Description, string Body, string? Mcp);
 
     private static string GetMimeType(string fileName)
     {

--- a/src/CrestApps.AgentSkills.Mcp/README.md
+++ b/src/CrestApps.AgentSkills.Mcp/README.md
@@ -183,7 +183,8 @@ Place your skill files in a directory and use the test infrastructure:
 
 ```csharp
 var fileStore = new PhysicalSkillFileStore("/path/to/skills");
-var provider = new SkillPromptProvider(fileStore, NullLogger<SkillPromptProvider>.Instance);
+var options = Options.Create(new AgentSkillOptions());
+var provider = new SkillPromptProvider(fileStore, NullLogger<SkillPromptProvider>.Instance, options);
 var prompts = await provider.GetPromptsAsync();
 ```
 

--- a/src/CrestApps.AgentSkills.Mcp/Services/McpChannelResolver.cs
+++ b/src/CrestApps.AgentSkills.Mcp/Services/McpChannelResolver.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.AgentSkills.Mcp.Services;
+
+/// <summary>
+/// Resolves the raw <c>mcp</c> front-matter value into an effective <see cref="McpChannel"/>.
+/// </summary>
+public static class McpChannelResolver
+{
+    /// <summary>
+    /// Resolves the effective MCP channel for a skill.
+    /// An absent value falls back to <paramref name="defaultChannel"/>; an unrecognized value
+    /// logs a warning and falls back to <paramref name="defaultChannel"/>.
+    /// </summary>
+    /// <param name="rawValue">The raw <c>mcp</c> value from the skill's front-matter, or <c>null</c>.</param>
+    /// <param name="defaultChannel">The channel to fall back to when the value is absent or invalid.</param>
+    /// <param name="skillName">The skill name, used for logging.</param>
+    /// <param name="logger">The logger used to warn on invalid values.</param>
+    /// <returns>The effective <see cref="McpChannel"/>.</returns>
+    public static McpChannel Resolve(string? rawValue, McpChannel defaultChannel, string skillName, ILogger logger)
+    {
+        if (string.IsNullOrWhiteSpace(rawValue))
+        {
+            return defaultChannel;
+        }
+
+        if (Enum.TryParse<McpChannel>(rawValue.Trim(), ignoreCase: true, out var channel)
+            && Enum.IsDefined(channel))
+        {
+            return channel;
+        }
+
+        logger.LogWarning(
+            "Skill '{SkillName}' declares an unrecognized mcp channel '{McpValue}'; falling back to the default channel '{DefaultChannel}'.",
+            skillName, rawValue, defaultChannel);
+
+        return defaultChannel;
+    }
+}

--- a/src/CrestApps.AgentSkills.Mcp/Services/SkillDocument.cs
+++ b/src/CrestApps.AgentSkills.Mcp/Services/SkillDocument.cs
@@ -1,0 +1,34 @@
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace CrestApps.AgentSkills.Mcp.Services;
+
+/// <summary>
+/// Shared YAML deserialization primitives for skill front-matter and YAML skill files.
+/// Only top-level keys are read; nested and unknown keys (for example <c>license</c>,
+/// <c>metadata</c>, <c>version</c>) are ignored.
+/// </summary>
+internal static class SkillDocument
+{
+    /// <summary>
+    /// A shared deserializer configured to match the top-level skill keys and ignore everything else.
+    /// </summary>
+    public static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    /// <summary>
+    /// Represents the recognized top-level keys of a skill document.
+    /// </summary>
+    public sealed class Model
+    {
+        public string? Name { get; set; }
+
+        public string? Description { get; set; }
+
+        public string? Body { get; set; }
+
+        public string? Mcp { get; set; }
+    }
+}

--- a/src/CrestApps.AgentSkills.Mcp/Services/SkillFileParser.cs
+++ b/src/CrestApps.AgentSkills.Mcp/Services/SkillFileParser.cs
@@ -23,9 +23,32 @@ public static class SkillFileParser
         out string description,
         out string body)
     {
+        return TryParse(fileName, content, out name, out description, out body, out _);
+    }
+
+    /// <summary>
+    /// Attempts to parse a skill file by detecting its format from the file name,
+    /// additionally surfacing the optional <c>mcp</c> channel declaration.
+    /// </summary>
+    /// <param name="fileName">The file name or path used to determine the format (e.g., <c>SKILL.md</c> or <c>SKILL.yaml</c>).</param>
+    /// <param name="content">The full content of the skill file.</param>
+    /// <param name="name">The parsed <c>name</c> field.</param>
+    /// <param name="description">The parsed <c>description</c> field.</param>
+    /// <param name="body">The parsed body content.</param>
+    /// <param name="mcp">The raw <c>mcp</c> value, or <c>null</c> when not declared.</param>
+    /// <returns><c>true</c> if the file was parsed successfully with all required fields; otherwise <c>false</c>.</returns>
+    public static bool TryParse(
+        string fileName,
+        string content,
+        out string name,
+        out string description,
+        out string body,
+        out string? mcp)
+    {
         name = string.Empty;
         description = string.Empty;
         body = string.Empty;
+        mcp = null;
 
         if (string.IsNullOrWhiteSpace(fileName) || string.IsNullOrWhiteSpace(content))
         {
@@ -34,13 +57,13 @@ public static class SkillFileParser
 
         if (fileName.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
         {
-            return SkillFrontMatterParser.TryParse(content, out name, out description, out body);
+            return SkillFrontMatterParser.TryParse(content, out name, out description, out body, out mcp);
         }
 
         if (fileName.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase)
             || fileName.EndsWith(".yml", StringComparison.OrdinalIgnoreCase))
         {
-            return SkillYamlParser.TryParse(content, out name, out description, out body);
+            return SkillYamlParser.TryParse(content, out name, out description, out body, out mcp);
         }
 
         return false;

--- a/src/CrestApps.AgentSkills.Mcp/Services/SkillFrontMatterParser.cs
+++ b/src/CrestApps.AgentSkills.Mcp/Services/SkillFrontMatterParser.cs
@@ -3,6 +3,9 @@ namespace CrestApps.AgentSkills.Mcp.Services;
 /// <summary>
 /// Parses YAML front-matter from SKILL.md files.
 /// Front-matter is delimited by <c>---</c> markers at the start of the file.
+/// The front-matter block is deserialized with YamlDotNet, reading only the top-level
+/// <c>name</c>, <c>description</c>, and (optional) <c>mcp</c> keys; nested/unknown keys
+/// (for example <c>license</c>, <c>metadata</c>, <c>version</c>) are ignored.
 /// </summary>
 public static class SkillFrontMatterParser
 {
@@ -18,9 +21,25 @@ public static class SkillFrontMatterParser
     /// <returns><c>true</c> if valid front-matter with required fields was found; otherwise <c>false</c>.</returns>
     public static bool TryParse(string content, out string name, out string description, out string body)
     {
+        return TryParse(content, out name, out description, out body, out _);
+    }
+
+    /// <summary>
+    /// Attempts to parse a SKILL.md file, extracting the front-matter fields, body content,
+    /// and the optional <c>mcp</c> channel declaration.
+    /// </summary>
+    /// <param name="content">The full content of the SKILL.md file.</param>
+    /// <param name="name">The parsed <c>name</c> field from front-matter.</param>
+    /// <param name="description">The parsed <c>description</c> field from front-matter.</param>
+    /// <param name="body">The body content after the closing <c>---</c> delimiter.</param>
+    /// <param name="mcp">The raw <c>mcp</c> front-matter value, or <c>null</c> when not declared.</param>
+    /// <returns><c>true</c> if valid front-matter with required fields was found; otherwise <c>false</c>.</returns>
+    public static bool TryParse(string content, out string name, out string description, out string body, out string? mcp)
+    {
         name = string.Empty;
         description = string.Empty;
         body = string.Empty;
+        mcp = null;
 
         if (string.IsNullOrWhiteSpace(content))
         {
@@ -70,35 +89,31 @@ public static class SkillFrontMatterParser
             ? trimmedContent[bodyStart..]
             : string.Empty;
 
-        // Parse the front-matter key-value pairs (simple line-based YAML parsing).
-        foreach (var line in frontMatter.Split('\n'))
+        // Deserialize the front-matter block with YamlDotNet, reading only top-level keys.
+        SkillDocument.Model? model;
+
+        try
         {
-            var trimmedLine = line.Trim();
-
-            if (trimmedLine.Length == 0 || trimmedLine.StartsWith('#'))
-            {
-                continue;
-            }
-
-            var colonIndex = trimmedLine.IndexOf(':');
-            if (colonIndex <= 0)
-            {
-                continue;
-            }
-
-            var key = trimmedLine[..colonIndex].Trim();
-            var value = trimmedLine[(colonIndex + 1)..].Trim();
-
-            if (string.Equals(key, "name", StringComparison.OrdinalIgnoreCase))
-            {
-                name = value;
-            }
-            else if (string.Equals(key, "description", StringComparison.OrdinalIgnoreCase))
-            {
-                description = value;
-            }
+            model = SkillDocument.Deserializer.Deserialize<SkillDocument.Model>(frontMatter);
+        }
+        catch
+        {
+            return false;
         }
 
-        return name.Length > 0 && description.Length > 0;
+        if (model is null
+            || string.IsNullOrWhiteSpace(model.Name)
+            || string.IsNullOrWhiteSpace(model.Description))
+        {
+            name = string.Empty;
+            description = string.Empty;
+            return false;
+        }
+
+        name = model.Name.Trim();
+        description = model.Description.Trim();
+        mcp = string.IsNullOrWhiteSpace(model.Mcp) ? null : model.Mcp.Trim();
+
+        return true;
     }
 }

--- a/src/CrestApps.AgentSkills.Mcp/Services/SkillYamlParser.cs
+++ b/src/CrestApps.AgentSkills.Mcp/Services/SkillYamlParser.cs
@@ -1,20 +1,13 @@
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
-
 namespace CrestApps.AgentSkills.Mcp.Services;
 
 /// <summary>
 /// Parses skill definitions from YAML (<c>.yaml</c> / <c>.yml</c>) files.
 /// Expects a YAML document with at least <c>name</c> and <c>description</c> fields.
-/// An optional <c>body</c> field provides the skill body content.
+/// An optional <c>body</c> field provides the skill body content and an optional
+/// <c>mcp</c> field declares the MCP channel.
 /// </summary>
 public static class SkillYamlParser
 {
-    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .IgnoreUnmatchedProperties()
-        .Build();
-
     /// <summary>
     /// Attempts to parse a YAML skill file, extracting the required fields.
     /// </summary>
@@ -25,9 +18,25 @@ public static class SkillYamlParser
     /// <returns><c>true</c> if valid YAML with required fields was found; otherwise <c>false</c>.</returns>
     public static bool TryParse(string content, out string name, out string description, out string body)
     {
+        return TryParse(content, out name, out description, out body, out _);
+    }
+
+    /// <summary>
+    /// Attempts to parse a YAML skill file, extracting the required fields and the optional
+    /// <c>mcp</c> channel declaration.
+    /// </summary>
+    /// <param name="content">The full content of the YAML file.</param>
+    /// <param name="name">The parsed <c>name</c> field.</param>
+    /// <param name="description">The parsed <c>description</c> field.</param>
+    /// <param name="body">The parsed <c>body</c> field, or empty if not present.</param>
+    /// <param name="mcp">The raw <c>mcp</c> value, or <c>null</c> when not declared.</param>
+    /// <returns><c>true</c> if valid YAML with required fields was found; otherwise <c>false</c>.</returns>
+    public static bool TryParse(string content, out string name, out string description, out string body, out string? mcp)
+    {
         name = string.Empty;
         description = string.Empty;
         body = string.Empty;
+        mcp = null;
 
         if (string.IsNullOrWhiteSpace(content))
         {
@@ -36,7 +45,7 @@ public static class SkillYamlParser
 
         try
         {
-            var skill = Deserializer.Deserialize<SkillYamlModel>(content);
+            var skill = SkillDocument.Deserializer.Deserialize<SkillDocument.Model>(content);
 
             if (skill is null
                 || string.IsNullOrWhiteSpace(skill.Name)
@@ -48,6 +57,7 @@ public static class SkillYamlParser
             name = skill.Name.Trim();
             description = skill.Description.Trim();
             body = skill.Body?.Trim() ?? string.Empty;
+            mcp = string.IsNullOrWhiteSpace(skill.Mcp) ? null : skill.Mcp.Trim();
 
             return true;
         }
@@ -55,14 +65,5 @@ public static class SkillYamlParser
         {
             return false;
         }
-    }
-
-    private sealed class SkillYamlModel
-    {
-        public string? Name { get; set; }
-
-        public string? Description { get; set; }
-
-        public string? Body { get; set; }
     }
 }

--- a/test/CrestApps.AgentSkills.Mcp.OrchardCore.Tests/FileSystemSkillPromptProviderTests.cs
+++ b/test/CrestApps.AgentSkills.Mcp.OrchardCore.Tests/FileSystemSkillPromptProviderTests.cs
@@ -1,6 +1,8 @@
+using CrestApps.AgentSkills.Mcp;
 using CrestApps.AgentSkills.Mcp.Providers;
 using CrestApps.AgentSkills.Mcp.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace CrestApps.OrchardCore.AgentSkills.Mcp.Tests;
@@ -35,7 +37,7 @@ public sealed class FileSystemSkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var prompts = await provider.GetPromptsAsync();
@@ -54,7 +56,7 @@ public sealed class FileSystemSkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var prompts = await provider.GetPromptsAsync();
@@ -75,7 +77,7 @@ public sealed class FileSystemSkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var prompts = await provider.GetPromptsAsync();
@@ -96,7 +98,7 @@ public sealed class FileSystemSkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var prompts = await provider.GetPromptsAsync();
@@ -117,7 +119,7 @@ public sealed class FileSystemSkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var first = await provider.GetPromptsAsync();
@@ -133,7 +135,7 @@ public sealed class FileSystemSkillPromptProviderTests : IDisposable
         // Arrange: empty directory, no skill subdirectories
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var prompts = await provider.GetPromptsAsync();
@@ -152,7 +154,7 @@ public sealed class FileSystemSkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var prompts = await provider.GetPromptsAsync();

--- a/test/CrestApps.AgentSkills.Mcp.OrchardCore.Tests/FileSystemSkillResourceProviderTests.cs
+++ b/test/CrestApps.AgentSkills.Mcp.OrchardCore.Tests/FileSystemSkillResourceProviderTests.cs
@@ -1,6 +1,8 @@
+using CrestApps.AgentSkills.Mcp;
 using CrestApps.AgentSkills.Mcp.Providers;
 using CrestApps.AgentSkills.Mcp.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace CrestApps.OrchardCore.AgentSkills.Mcp.Tests;
@@ -33,7 +35,7 @@ public sealed class FileSystemSkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var resources = await provider.GetResourcesAsync();
@@ -59,7 +61,7 @@ public sealed class FileSystemSkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var resources = await provider.GetResourcesAsync();
@@ -85,7 +87,7 @@ public sealed class FileSystemSkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var resources = await provider.GetResourcesAsync();
@@ -106,7 +108,7 @@ public sealed class FileSystemSkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var resources = await provider.GetResourcesAsync();
@@ -127,7 +129,7 @@ public sealed class FileSystemSkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var first = await provider.GetResourcesAsync();
@@ -143,7 +145,7 @@ public sealed class FileSystemSkillResourceProviderTests : IDisposable
         // Arrange: empty directory
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var resources = await provider.GetResourcesAsync();
@@ -162,7 +164,7 @@ public sealed class FileSystemSkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         // Act
         var resources = await provider.GetResourcesAsync();

--- a/test/CrestApps.AgentSkills.Mcp.OrchardCore.Tests/OrchardCoreSkillOptionsBridgeTests.cs
+++ b/test/CrestApps.AgentSkills.Mcp.OrchardCore.Tests/OrchardCoreSkillOptionsBridgeTests.cs
@@ -1,0 +1,45 @@
+using CrestApps.AgentSkills.Mcp;
+using CrestApps.OrchardCore.AgentSkills.Mcp.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace CrestApps.OrchardCore.AgentSkills.Mcp.Tests;
+
+/// <summary>
+/// Verifies that OrchardCoreSkillOptions flows through the standard options pipeline
+/// and is bridged onto the underlying AgentSkillOptions.
+/// </summary>
+public sealed class OrchardCoreSkillOptionsBridgeTests
+{
+    [Fact]
+    public void OrchardCoreOptions_AreResolvableViaIOptions_AndBridgeOntoAgentSkillOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddOrchardCoreAgentSkillServices(o => o.Path = "/custom/skills/path");
+
+        using var provider = services.BuildServiceProvider();
+
+        var orchardOptions = provider.GetRequiredService<IOptions<OrchardCoreSkillOptions>>().Value;
+        var agentOptions = provider.GetRequiredService<IOptions<AgentSkillOptions>>().Value;
+
+        Assert.Equal("/custom/skills/path", orchardOptions.Path);
+        Assert.Equal("/custom/skills/path", agentOptions.Path);
+    }
+
+    [Fact]
+    public void PostConfigure_OrchardCoreOptions_FlowsToAgentSkillOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddOrchardCoreAgentSkillServices(o => o.Path = "/initial");
+
+        // A later post-configuration must be honored (the benefit of the options pipeline).
+        services.Configure<OrchardCoreSkillOptions>(o => o.Path = "/overridden");
+
+        using var provider = services.BuildServiceProvider();
+
+        var agentOptions = provider.GetRequiredService<IOptions<AgentSkillOptions>>().Value;
+
+        Assert.Equal("/overridden", agentOptions.Path);
+    }
+}

--- a/test/CrestApps.AgentSkills.Mcp.Tests/SkillFrontMatterParserTests.cs
+++ b/test/CrestApps.AgentSkills.Mcp.Tests/SkillFrontMatterParserTests.cs
@@ -117,4 +117,101 @@ public sealed class SkillFrontMatterParserTests
         Assert.Equal("A test skill.", description);
         Assert.StartsWith("# Body Content", body);
     }
+
+    [Fact]
+    public void TryParse_FoldedDescription_JoinsLinesAndTrims()
+    {
+        var content = "---\nname: folded-skill\ndescription: >\n  This is a folded\n  description value.\n---\n# Body";
+
+        var result = SkillFrontMatterParser.TryParse(content, out var name, out var description, out _);
+
+        Assert.True(result);
+        Assert.Equal("folded-skill", name);
+        Assert.Equal("This is a folded description value.", description);
+    }
+
+    [Fact]
+    public void TryParse_QuotedValues_StripsQuotes()
+    {
+        var content = "---\nname: \"quoted-skill\"\ndescription: 'A quoted description.'\n---\n# Body";
+
+        var result = SkillFrontMatterParser.TryParse(content, out var name, out var description, out _);
+
+        Assert.True(result);
+        Assert.Equal("quoted-skill", name);
+        Assert.Equal("A quoted description.", description);
+    }
+
+    [Fact]
+    public void TryParse_NestedMetadataKeys_DoNotOverrideTopLevel()
+    {
+        var content =
+            "---\n" +
+            "name: real-name\n" +
+            "description: Real description.\n" +
+            "metadata:\n" +
+            "  name: nested-name\n" +
+            "  description: nested description.\n" +
+            "  author: someone\n" +
+            "---\n" +
+            "# Body";
+
+        var result = SkillFrontMatterParser.TryParse(content, out var name, out var description, out _);
+
+        Assert.True(result);
+        Assert.Equal("real-name", name);
+        Assert.Equal("Real description.", description);
+    }
+
+    [Fact]
+    public void TryParse_IgnoresUnknownTopLevelKeys()
+    {
+        var content =
+            "---\n" +
+            "name: skill\n" +
+            "description: Desc.\n" +
+            "license: MIT\n" +
+            "version: 1.2.3\n" +
+            "---\n" +
+            "# Body";
+
+        var result = SkillFrontMatterParser.TryParse(content, out var name, out var description, out _);
+
+        Assert.True(result);
+        Assert.Equal("skill", name);
+        Assert.Equal("Desc.", description);
+    }
+
+    [Fact]
+    public void TryParse_McpKey_IsExtracted()
+    {
+        var content = "---\nname: skill\ndescription: Desc.\nmcp: resource\n---\n# Body";
+
+        var result = SkillFrontMatterParser.TryParse(content, out _, out _, out _, out var mcp);
+
+        Assert.True(result);
+        Assert.Equal("resource", mcp);
+    }
+
+    [Fact]
+    public void TryParse_NoMcpKey_ReturnsNullMcp()
+    {
+        var content = "---\nname: skill\ndescription: Desc.\n---\n# Body";
+
+        var result = SkillFrontMatterParser.TryParse(content, out _, out _, out _, out var mcp);
+
+        Assert.True(result);
+        Assert.Null(mcp);
+    }
+
+    [Fact]
+    public void TryParse_NestedNameOnly_MissingTopLevelName_ReturnsFalse()
+    {
+        // A skill that only defines name under metadata must NOT be considered valid.
+        var content = "---\ndescription: Desc.\nmetadata:\n  name: nested-name\n---\n# Body";
+
+        var result = SkillFrontMatterParser.TryParse(content, out _, out _, out _);
+
+        Assert.False(result);
+    }
 }

--- a/test/CrestApps.AgentSkills.Mcp.Tests/SkillMcpChannelTests.cs
+++ b/test/CrestApps.AgentSkills.Mcp.Tests/SkillMcpChannelTests.cs
@@ -1,0 +1,217 @@
+using System.Reflection;
+using CrestApps.AgentSkills.Mcp;
+using CrestApps.AgentSkills.Mcp.Providers;
+using CrestApps.AgentSkills.Mcp.Services;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Server;
+using Xunit;
+
+namespace CrestApps.AgentSkills.Mcp.Tests;
+
+/// <summary>
+/// Covers the <c>mcp</c> channel gating (Fix 1) and the resource body-strip
+/// consistency with the prompt (Fix 3).
+/// </summary>
+public sealed class SkillMcpChannelTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public SkillMcpChannelTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"agent-skills-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    private async Task WriteSkillAsync(string dirName, string content)
+    {
+        var skillDir = Path.Combine(_tempDir, dirName);
+        Directory.CreateDirectory(skillDir);
+        await File.WriteAllTextAsync(Path.Combine(skillDir, "SKILL.md"), content, TestContext.Current.CancellationToken);
+    }
+
+    private SkillPromptProvider CreatePromptProvider(AgentSkillOptions options = null)
+        => new(new DefaultAgentSkillFilesStore(_tempDir), NullLogger<SkillPromptProvider>.Instance, Accessor(options));
+
+    private SkillResourceProvider CreateResourceProvider(AgentSkillOptions options = null)
+        => new(new DefaultAgentSkillFilesStore(_tempDir), NullLogger<SkillResourceProvider>.Instance, Accessor(options));
+
+    private static IOptions<AgentSkillOptions> Accessor(AgentSkillOptions options)
+        => Options.Create(options ?? new AgentSkillOptions());
+
+    // ----- Channel gating: prompt provider -----
+
+    [Fact]
+    public async Task PromptProvider_DefaultBoth_EmitsPrompt()
+    {
+        await WriteSkillAsync("s", "---\nname: s\ndescription: d.\n---\n# Body");
+
+        var prompts = await CreatePromptProvider().GetPromptsAsync();
+
+        Assert.Single(prompts);
+    }
+
+    [Fact]
+    public async Task PromptProvider_McpPrompt_EmitsPrompt()
+    {
+        await WriteSkillAsync("s", "---\nname: s\ndescription: d.\nmcp: prompt\n---\n# Body");
+
+        var prompts = await CreatePromptProvider().GetPromptsAsync();
+
+        Assert.Single(prompts);
+    }
+
+    [Fact]
+    public async Task PromptProvider_McpResource_DoesNotEmitPrompt()
+    {
+        await WriteSkillAsync("s", "---\nname: s\ndescription: d.\nmcp: resource\n---\n# Body");
+
+        var prompts = await CreatePromptProvider().GetPromptsAsync();
+
+        Assert.Empty(prompts);
+    }
+
+    [Fact]
+    public async Task PromptProvider_InvalidMcp_FallsBackToDefault()
+    {
+        await WriteSkillAsync("s", "---\nname: s\ndescription: d.\nmcp: bogus\n---\n# Body");
+
+        // Default is Both, so a prompt is still emitted.
+        var prompts = await CreatePromptProvider().GetPromptsAsync();
+
+        Assert.Single(prompts);
+    }
+
+    [Fact]
+    public async Task PromptProvider_DefaultChannelResource_OmitsPromptWhenKeyAbsent()
+    {
+        await WriteSkillAsync("s", "---\nname: s\ndescription: d.\n---\n# Body");
+
+        var options = new AgentSkillOptions { DefaultMcpChannel = McpChannel.Resource };
+        var prompts = await CreatePromptProvider(options).GetPromptsAsync();
+
+        Assert.Empty(prompts);
+    }
+
+    // ----- Channel gating: resource provider -----
+
+    [Fact]
+    public async Task ResourceProvider_DefaultBoth_EmitsSkillResource()
+    {
+        await WriteSkillAsync("s", "---\nname: s\ndescription: d.\n---\n# Body");
+
+        var resources = await CreateResourceProvider().GetResourcesAsync();
+
+        Assert.Single(resources);
+    }
+
+    [Fact]
+    public async Task ResourceProvider_McpResource_EmitsSkillResource()
+    {
+        await WriteSkillAsync("s", "---\nname: s\ndescription: d.\nmcp: resource\n---\n# Body");
+
+        var resources = await CreateResourceProvider().GetResourcesAsync();
+
+        Assert.Single(resources);
+    }
+
+    [Fact]
+    public async Task ResourceProvider_McpPrompt_OmitsSkillResourceButKeepsReferences()
+    {
+        await WriteSkillAsync("s", "---\nname: s\ndescription: d.\nmcp: prompt\n---\n# Body");
+        var refsDir = Path.Combine(_tempDir, "s", "references");
+        Directory.CreateDirectory(refsDir);
+        await File.WriteAllTextAsync(Path.Combine(refsDir, "ref.md"), "# Reference", TestContext.Current.CancellationToken);
+
+        var resources = await CreateResourceProvider().GetResourcesAsync();
+
+        // SKILL.md resource is suppressed; the reference file is still exposed.
+        Assert.Single(resources);
+        Assert.Contains(resources, r => r.ProtocolResource?.Uri == "skills://s/references/ref.md");
+        Assert.DoesNotContain(resources, r => r.ProtocolResource?.Uri == "skills://s/SKILL.md");
+    }
+
+    [Fact]
+    public async Task ResourceProvider_DefaultChannelPrompt_OmitsSkillResourceWhenKeyAbsent()
+    {
+        await WriteSkillAsync("s", "---\nname: s\ndescription: d.\n---\n# Body");
+
+        var options = new AgentSkillOptions { DefaultMcpChannel = McpChannel.Prompt };
+        var resources = await CreateResourceProvider(options).GetResourcesAsync();
+
+        Assert.Empty(resources);
+    }
+
+    // ----- Body-strip consistency (Fix 3) -----
+
+    [Fact]
+    public async Task ResourceProvider_ServesFrontMatterStrippedBody()
+    {
+        var content =
+            "---\n" +
+            "name: s\n" +
+            "description: d.\n" +
+            "license: SECRET-LICENSE\n" +
+            "metadata:\n" +
+            "  author: private-author\n" +
+            "---\n" +
+            "# Real Body\nVisible content.";
+        await WriteSkillAsync("s", content);
+
+        var resources = await CreateResourceProvider().GetResourcesAsync();
+        var resource = Assert.Single(resources);
+
+        var served = ReadResourceText(resource);
+
+        Assert.Equal("# Real Body\nVisible content.", served);
+        Assert.DoesNotContain("SECRET-LICENSE", served, StringComparison.Ordinal);
+        Assert.DoesNotContain("private-author", served, StringComparison.Ordinal);
+        Assert.DoesNotContain("---", served, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ResourceAndPrompt_ServeIdenticalBody()
+    {
+        var content = "---\nname: s\ndescription: d.\nlicense: MIT\n---\n# Shared Body\nText.";
+        await WriteSkillAsync("s", content);
+
+        var prompts = await CreatePromptProvider().GetPromptsAsync();
+        var resources = await CreateResourceProvider().GetResourcesAsync();
+
+        var promptBody = ReadPromptText(Assert.Single(prompts));
+        var resourceBody = ReadResourceText(Assert.Single(resources));
+
+        Assert.Equal(promptBody, resourceBody);
+        Assert.Equal("# Shared Body\nText.", resourceBody);
+    }
+
+    private static string ReadResourceText(McpServerResource resource)
+        => InvokeBackingFunction(resource);
+
+    private static string ReadPromptText(McpServerPrompt prompt)
+        => InvokeBackingFunction(prompt);
+
+    private static string InvokeBackingFunction(object primitive)
+    {
+        var field = primitive.GetType().GetField(
+            "<AIFunction>k__BackingField",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(field);
+
+        var function = (AIFunction)field!.GetValue(primitive)!;
+        var result = function.InvokeAsync(new AIFunctionArguments(), CancellationToken.None)
+            .AsTask().GetAwaiter().GetResult();
+
+        return result?.ToString() ?? string.Empty;
+    }
+}

--- a/test/CrestApps.AgentSkills.Mcp.Tests/SkillPromptProviderTests.cs
+++ b/test/CrestApps.AgentSkills.Mcp.Tests/SkillPromptProviderTests.cs
@@ -1,6 +1,7 @@
 using CrestApps.AgentSkills.Mcp.Providers;
 using CrestApps.AgentSkills.Mcp.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace CrestApps.AgentSkills.Mcp.Tests;
@@ -34,7 +35,7 @@ public sealed class SkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var prompts = await provider.GetPromptsAsync();
 
@@ -52,7 +53,7 @@ public sealed class SkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var prompts = await provider.GetPromptsAsync();
 
@@ -70,7 +71,7 @@ public sealed class SkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var prompts = await provider.GetPromptsAsync();
 
@@ -86,7 +87,7 @@ public sealed class SkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var prompts = await provider.GetPromptsAsync();
 
@@ -104,7 +105,7 @@ public sealed class SkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var prompts = await provider.GetPromptsAsync();
 
@@ -122,7 +123,7 @@ public sealed class SkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var prompts = await provider.GetPromptsAsync();
 
@@ -140,7 +141,7 @@ public sealed class SkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var prompts = await provider.GetPromptsAsync();
 
@@ -158,7 +159,7 @@ public sealed class SkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var first = await provider.GetPromptsAsync();
         var second = await provider.GetPromptsAsync();
@@ -171,7 +172,7 @@ public sealed class SkillPromptProviderTests : IDisposable
     {
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var prompts = await provider.GetPromptsAsync();
 
@@ -187,7 +188,7 @@ public sealed class SkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var prompts = await provider.GetPromptsAsync();
 
@@ -209,7 +210,7 @@ public sealed class SkillPromptProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillPromptProvider(
-            fileStore, NullLogger<SkillPromptProvider>.Instance);
+            fileStore, NullLogger<SkillPromptProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var prompts = await provider.GetPromptsAsync();
 

--- a/test/CrestApps.AgentSkills.Mcp.Tests/SkillResourceProviderTests.cs
+++ b/test/CrestApps.AgentSkills.Mcp.Tests/SkillResourceProviderTests.cs
@@ -1,6 +1,7 @@
 using CrestApps.AgentSkills.Mcp.Providers;
 using CrestApps.AgentSkills.Mcp.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace CrestApps.AgentSkills.Mcp.Tests;
@@ -34,7 +35,7 @@ public sealed class SkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var resources = await provider.GetResourcesAsync();
 
@@ -52,7 +53,7 @@ public sealed class SkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var resources = await provider.GetResourcesAsync();
 
@@ -70,7 +71,7 @@ public sealed class SkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var resources = await provider.GetResourcesAsync();
 
@@ -93,7 +94,7 @@ public sealed class SkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var resources = await provider.GetResourcesAsync();
 
@@ -117,7 +118,7 @@ public sealed class SkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var resources = await provider.GetResourcesAsync();
 
@@ -136,7 +137,7 @@ public sealed class SkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var resources = await provider.GetResourcesAsync();
 
@@ -154,7 +155,7 @@ public sealed class SkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var first = await provider.GetResourcesAsync();
         var second = await provider.GetResourcesAsync();
@@ -167,7 +168,7 @@ public sealed class SkillResourceProviderTests : IDisposable
     {
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var resources = await provider.GetResourcesAsync();
 
@@ -183,7 +184,7 @@ public sealed class SkillResourceProviderTests : IDisposable
 
         var fileStore = new DefaultAgentSkillFilesStore(_tempDir);
         var provider = new SkillResourceProvider(
-            fileStore, NullLogger<SkillResourceProvider>.Instance);
+            fileStore, NullLogger<SkillResourceProvider>.Instance, Options.Create(new AgentSkillOptions()));
 
         var resources = await provider.GetResourcesAsync();
 


### PR DESCRIPTION
Harden the SKILL.md front-matter parser and make prompt/resource exposure consistent and configurable.

- Parser: replace the hand-rolled line-based front-matter parsing with YamlDotNet (the same approach the .yaml/.yml parser already uses), reading only the top-level name/description/mcp keys. This fixes silent mis-parsing of folded (>) and quoted values and stops nested metadata.* keys from clobbering the real name/description. Existing TryParse signatures are preserved; new overloads surface the optional mcp key.

- Resource: serve the front-matter-stripped body for the SKILL resource (matching the prompt) instead of the full file, so internal YAML (license, metadata, version, ...) is no longer leaked to clients.

- Channel: skills may declare an optional `mcp` front-matter key (prompt | resource | both). A new AgentSkillOptions.DefaultMcpChannel (default: both) preserves current behavior. The prompt provider emits a prompt only for prompt/both; the resource provider emits the SKILL resource only for resource/both. references/*.md are always exposed.

Provider constructors keep their original two-argument form and add a new overload taking AgentSkillOptions, so the change is not binary-breaking.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://github.com/CrestApps/CrestApps.AgentSkills/blob/main/.github/CONTRIBUTING.md -->
